### PR TITLE
Make Vector iterable

### DIFF
--- a/sanpera/geometry.pyx
+++ b/sanpera/geometry.pyx
@@ -93,7 +93,7 @@ cdef class Vector:
 
     def __iter__(self):
         """Unpacks into `(x, y)`."""
-        return (self._x, self._y)
+        return iter((self._x, self._y))
 
     def __nonzero__(self):
         """Every `Vector` is truthy, except the zero vector."""

--- a/sanpera/tests/test_geometry.py
+++ b/sanpera/tests/test_geometry.py
@@ -10,6 +10,7 @@ def test_vector_origin():
     assert not vec
     assert vec.x == 0
     assert vec.y == 0
+    assert tuple(vec) == (0, 0)
 
 def test_vector_simple():
     vec = geom.Vector(3, 4)
@@ -32,6 +33,7 @@ def test_size_zero():
     assert size.height == 0
     assert size.x == 0
     assert size.y == 0
+    assert tuple(size) == (0, 0)
 
 
 def test_size_fit_area():


### PR DESCRIPTION
`Vector.__iter__` returned a tuple, when it should return an iterator:

```
>>> from sanpera.geometry import Size
>>> w, h = Size(1, 2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: iter() returned non-iterator of type 'tuple'
```

An extra iter() call fixes this.
