### PR TITLE
Stop relying on float division in sanpera.geometry.Size.

### DIFF
--- a/sanpera/geometry.pyx
+++ b/sanpera/geometry.pyx
@@ -9,6 +9,9 @@ from sanpera cimport c_api
 
 import math
 
+cdef int approx_equal(float f1, float f2, float epsilon=1e-6):
+    return abs(f1 - f2) < epsilon
+
 cdef class Vector:
     """I'm a direction and magnitude in a two-dimensional plane, where the axes
     increase rightwards and down.  I can also represent a single point.
@@ -295,6 +298,7 @@ cdef class Size(Vector):
         """Implementation for `fit_inside` and `fit_around`."""
 
         cdef Size coerced = self.__class__.coerce(other)
+        cdef float width_ratio, height_ratio, ratio
 
         if not upscale and (
                 self.width < coerced.width and self.height < coerced.height):
@@ -304,14 +308,14 @@ cdef class Size(Vector):
                 self.width > coerced.width and self.height > coerced.height):
             return self
 
-        ratio = minmax((
-            self.width / coerced.width,
-            self.height / coerced.height))
-
-        return self.__class__(
-            int(self.width / ratio),
-            int(self.height / ratio),
-        )
+        width_ratio = self.width / coerced.width
+        height_ratio = self.height / coerced.height
+        if approx_equal(width_ratio, height_ratio):
+            return coerced
+        elif approx_equal(minmax(width_ratio, height_ratio), width_ratio):
+            return self.__class__(coerced.width, int(self.height / width_ratio))
+        else:
+            return self.__class__(int(self.width / height_ratio), coerced.height)
 
 
 

--- a/sanpera/tests/test_geometry.py
+++ b/sanpera/tests/test_geometry.py
@@ -57,6 +57,16 @@ def test_size_fit_area():
     assert size.fit_area(10, emulate=True) == geom.Size(3, 4)
     assert size.fit_area(11, emulate=True) == geom.Size(3, 4)
 
+def test_size_fit_inside():
+    assert geom.Size(600, 398).fit_inside((120, 120)) == geom.Size(120, 79)
+    assert geom.Size(398, 600).fit_inside((120, 120)) == geom.Size(79, 120)
+    assert geom.Size(398, 398).fit_inside((120, 120)) == geom.Size(120, 120)
+
+def test_size_fit_around():
+    assert geom.Size(600, 398).fit_around((120, 120)) == geom.Size(180, 120)
+    assert geom.Size(398, 600).fit_around((120, 120)) == geom.Size(120, 180)
+    assert geom.Size(398, 398).fit_around((120, 120)) == geom.Size(120, 120)
+
 def test_rect_zero():
     assert geom.Rectangle(0, 0, 10, 10)
     assert not geom.Rectangle(5, 5, 5, 10)


### PR DESCRIPTION
In some cases, where `x` and `y` are both ints, `int(x/(x/y)) != y`. It's easier to not rely on this at all and use the original dimensions when possible.

The code might be able to be simplified a bit more, but this seems good enough to me.
