### PR TITLE
Use ImagesToBlob instead of ImageToBlob

### DIFF
--- a/sanpera/image.py
+++ b/sanpera/image.py
@@ -312,7 +312,7 @@ class Image(object):
 
         with magick_try() as exc:
             cbuf = ffi.gc(
-                lib.ImageToBlob(image_info, self._stack, length, exc.ptr),
+                lib.ImagesToBlob(image_info, self._stack, length, exc.ptr),
                 lib.RelinquishMagickMemory)
 
         return ffi.buffer(cbuf, length[0])


### PR DESCRIPTION
ImageToBlob will implicitly flatten stacks of images instead of writing out every image in the stack. This is most noticable when writing out animated GIFs. As far as I can tell, this doesn't affect anything other than treating stacks of >1 image correctly, but a bunch of the tests fail even without this patch applied.
