### PR TITLE
Don't try to cast a python string in Image.from_buffer

### DIFF
--- a/sanpera/image.py
+++ b/sanpera/image.py
@@ -261,9 +261,8 @@ class Image(object):
         assert isinstance(buf, bytes)
 
         image_info = blank_image_info()
-        c_buf = ffi.cast("void *", ffi.cast("char *", buf))
         with magick_try() as exc:
-            ptr = lib.BlobToImage(image_info, c_buf, len(buf), exc.ptr)
+            ptr = lib.BlobToImage(image_info, buf, len(buf), exc.ptr)
             exc.check(ptr == ffi.NULL)
 
         return cls(ptr)


### PR DESCRIPTION
Doing this just results in an error, and isn't necessary anyway. cffi accepts python strings as `void *` arguments.

The error I get, at least, is:

```
>>> image.ffi.cast('char *', 'dongs')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../local/lib/python2.7/site-packages/cffi/api.py", line 233, in cast
return self._backend.cast(cdecl, source)
TypeError: an integer is required
```
