### PR TITLE
[ISSUE-25] - Colorfast resizing of non-linear RGB images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ MANIFEST
 /build
 /dist
 /*.egg-info/
+/*.egg
 
 /doc/_build

--- a/demo-program.py
+++ b/demo-program.py
@@ -11,7 +11,7 @@ def demo_program():
         print "Reading %s ..." % (fn,)
         #img = Image.from_filename(fn)
         #img = Image.from_buffer(open(fn).read())
-        img = Image.read(open(fn))
+        img = Image.read(fn)
         print " %lu frames" % (len(img),)
         images.extend(img)
 
@@ -19,7 +19,7 @@ def demo_program():
         raise IOError("Failed to read any images!")
 
     # Create a thumbnail image sequence
-    thumbnails = images.resize(106, 80)
+    thumbnails = images.resized((106, 80))
     del img
     del images
 

--- a/sanpera/_api.h
+++ b/sanpera/_api.h
@@ -16,9 +16,6 @@ struct _ImageInfo;
 typedef struct _ImageInfo ImageInfo;
 typedef ... CacheView;
 
-
-
-
 // =============================================================================
 // independent stuff
 // -----------------------------------------------------------------------------
@@ -416,151 +413,6 @@ void GetMagickPixelPacket(const Image *, MagickPixelPacket *);
 //MagickBooleanType ImportImagePixels(Image *, const ssize_t, const ssize_t, const size_t, const size_t, const char *, const StorageType, const void *);
 MagickBooleanType InterpolateMagickPixelPacket(const Image *, const CacheView *, const InterpolatePixelMethod, const double, const double, MagickPixelPacket *, ExceptionInfo *);
 
-
-// =============================================================================
-// the important stuff
-// -----------------------------------------------------------------------------
-// image.h
-
-// TODO some defines for opacity up here
-
-typedef enum {
-    UndefinedAlphaChannel,
-    ActivateAlphaChannel,
-    BackgroundAlphaChannel,
-    CopyAlphaChannel,
-    DeactivateAlphaChannel,
-    ExtractAlphaChannel,
-    OpaqueAlphaChannel,
-    SetAlphaChannel,
-    ShapeAlphaChannel,
-    TransparentAlphaChannel,
-    FlattenAlphaChannel,
-    RemoveAlphaChannel,
-    ...
-} AlphaChannelType;
-
-typedef enum {
-    ...
-} ImageType;
-
-typedef enum {
-    ...
-} InterlaceType;
-
-typedef enum {
-    ...
-} OrientationType;
-
-typedef enum {
-    ...
-} ResolutionType;
-
-typedef enum {
-    ...
-} PrimaryInfo;
-
-typedef struct {
-    double x1;
-    double y1;
-    double x2;
-    double y2;
-} SegmentInfo;
-
-typedef enum {
-    ...
-} TransmitType;
-
-typedef enum {
-    ...
-} ChromaticityInfo;
-
-
-struct _Image {
-    ClassType storage_class;
-
-    MagickBooleanType matte;
-
-    size_t columns;
-    size_t rows;
-    size_t depth;
-    size_t colors;
-
-    PixelPacket *colormap;
-
-    RectangleInfo page;
-
-    char magick[];
-    char filename[];
-
-    ExceptionInfo exception;
-
-    Image *previous;
-    Image *list;
-    Image *next;
-
-    ImageType type;
-
-    void *cache;
-
-    ...;
-};
-
-struct _ImageInfo {
-
-    MagickBooleanType adjoin;
-
-    FILE *file;
-
-    char magick[];
-    char filename[];
-    ...;
-};
-
-
-ImageInfo *AcquireImageInfo();
-Image *CloneImage(const Image *, const size_t, const size_t, const MagickBooleanType, ExceptionInfo *);
-ImageInfo *CloneImageInfo(const ImageInfo *);
-ImageInfo *DestroyImageInfo(ImageInfo *);
-Image *NewMagickImage(const ImageInfo *, const size_t, const size_t, const MagickPixelPacket *);
-Image *ReferenceImage(Image *);
-Image *DestroyImage(Image *);
-
-
-// -----------------------------------------------------------------------------
-// list.h
-// (done)
-
-void AppendImageToList(Image **, const Image *);
-Image *CloneImageList(const Image *, ExceptionInfo *);
-Image *CloneImages(const Image *, const char *, ExceptionInfo *);
-void DeleteImageFromList(Image **);
-void DeleteImages(Image **,const char *, ExceptionInfo *);
-Image *DestroyImageList(Image *);
-Image *DuplicateImages(Image *, const size_t, const char *, ExceptionInfo *);
-Image *GetFirstImageInList(const Image *);
-Image *GetImageFromList(const Image *, const ssize_t);
-ssize_t GetImageIndexInList(const Image *);
-size_t GetImageListLength(const Image *);
-Image *GetLastImageInList(const Image *);
-Image *GetNextImageInList(const Image *);
-Image *GetPreviousImageInList(const Image *);
-Image **ImageListToArray(const Image *, ExceptionInfo *);
-void InsertImageInList(Image **, Image *);
-Image *NewImageList();
-void PrependImageToList(Image **, Image *);
-Image *RemoveImageFromList(Image **);
-Image *RemoveLastImageFromList(Image **);
-Image *RemoveFirstImageFromList(Image **);
-void ReplaceImageInList(Image **, Image *);
-void ReplaceImageInListReturnLast(Image **, Image *);
-void ReverseImageList(Image **);
-Image *SpliceImageIntoList(Image **, const size_t, const Image *);
-Image *SplitImageList(Image *);
-void SyncImageList(Image *);
-Image *SyncNextImageInList(const Image *);
-
-
 // =============================================================================
 // color
 // -----------------------------------------------------------------------------
@@ -675,6 +527,149 @@ size_t GetCacheViewChannels(const CacheView *);
 PixelPacket *GetCacheViewAuthenticPixelQueue(CacheView *);
 PixelPacket *GetCacheViewAuthenticPixels(CacheView *, const ssize_t, const ssize_t, const size_t, const size_t, ExceptionInfo *);
 PixelPacket *QueueCacheViewAuthenticPixels(CacheView *, const ssize_t, const ssize_t, const size_t, const size_t, ExceptionInfo *);
+
+// =============================================================================
+// the important stuff
+// -----------------------------------------------------------------------------
+// image.h
+
+// TODO some defines for opacity up here
+
+typedef enum {
+    UndefinedAlphaChannel,
+    ActivateAlphaChannel,
+    BackgroundAlphaChannel,
+    CopyAlphaChannel,
+    DeactivateAlphaChannel,
+    ExtractAlphaChannel,
+    OpaqueAlphaChannel,
+    SetAlphaChannel,
+    ShapeAlphaChannel,
+    TransparentAlphaChannel,
+    FlattenAlphaChannel,
+    RemoveAlphaChannel,
+    ...
+} AlphaChannelType;
+
+typedef enum {
+    ...
+} ImageType;
+
+typedef enum {
+    ...
+} InterlaceType;
+
+typedef enum {
+    ...
+} OrientationType;
+
+typedef enum {
+    ...
+} ResolutionType;
+
+typedef enum {
+    ...
+} PrimaryInfo;
+
+typedef struct {
+    double x1;
+    double y1;
+    double x2;
+    double y2;
+} SegmentInfo;
+
+typedef enum {
+    ...
+} TransmitType;
+
+typedef enum {
+    ...
+} ChromaticityInfo;
+
+
+struct _Image {
+    ClassType storage_class;
+    ColorspaceType colorspace;
+    MagickBooleanType matte;
+
+    size_t columns;
+    size_t rows;
+    size_t depth;
+    size_t colors;
+
+    PixelPacket *colormap;
+
+    RectangleInfo page;
+
+    char magick[];
+    char filename[];
+
+    ExceptionInfo exception;
+
+    Image *previous;
+    Image *list;
+    Image *next;
+
+    ImageType type;
+
+    void *cache;
+
+    ...;
+};
+
+struct _ImageInfo {
+
+    MagickBooleanType adjoin;
+
+    FILE *file;
+
+    char magick[];
+    char filename[];
+    ...;
+};
+
+
+ImageInfo *AcquireImageInfo();
+Image *CloneImage(const Image *, const size_t, const size_t, const MagickBooleanType, ExceptionInfo *);
+ImageInfo *CloneImageInfo(const ImageInfo *);
+ImageInfo *DestroyImageInfo(ImageInfo *);
+Image *NewMagickImage(const ImageInfo *, const size_t, const size_t, const MagickPixelPacket *);
+Image *ReferenceImage(Image *);
+Image *DestroyImage(Image *);
+
+
+// -----------------------------------------------------------------------------
+// list.h
+// (done)
+
+void AppendImageToList(Image **, const Image *);
+Image *CloneImageList(const Image *, ExceptionInfo *);
+Image *CloneImages(const Image *, const char *, ExceptionInfo *);
+void DeleteImageFromList(Image **);
+void DeleteImages(Image **,const char *, ExceptionInfo *);
+Image *DestroyImageList(Image *);
+Image *DuplicateImages(Image *, const size_t, const char *, ExceptionInfo *);
+Image *GetFirstImageInList(const Image *);
+Image *GetImageFromList(const Image *, const ssize_t);
+ssize_t GetImageIndexInList(const Image *);
+size_t GetImageListLength(const Image *);
+Image *GetLastImageInList(const Image *);
+Image *GetNextImageInList(const Image *);
+Image *GetPreviousImageInList(const Image *);
+Image **ImageListToArray(const Image *, ExceptionInfo *);
+void InsertImageInList(Image **, Image *);
+Image *NewImageList();
+void PrependImageToList(Image **, Image *);
+Image *RemoveImageFromList(Image **);
+Image *RemoveLastImageFromList(Image **);
+Image *RemoveFirstImageFromList(Image **);
+void ReplaceImageInList(Image **, Image *);
+void ReplaceImageInListReturnLast(Image **, Image *);
+void ReverseImageList(Image **);
+Image *SpliceImageIntoList(Image **, const size_t, const Image *);
+Image *SplitImageList(Image *);
+void SyncImageList(Image *);
+Image *SyncNextImageInList(const Image *);
 
 
 // =============================================================================


### PR DESCRIPTION
Probably a little too general in that it assumes any non-linear RGB image space is going to get screwed up by the resize, but who knows, it's imagemagick. Better to assume it always does the wrong thing.

Could add a regression test for this if you want - it would just have to compare swatches of a resized sRGB image to the original pixel values. Would probably just be a small sample patch from the original test image.

Also adds `*.egg` to gitignore for `pip install -e` and quick-fixes some things in demo-program that made it not work correctly.

Closes Issue #25.
